### PR TITLE
Okwme suggestion

### DIFF
--- a/contracts/Question.sol
+++ b/contracts/Question.sol
@@ -64,6 +64,7 @@ contract Question {
     require(token.transferFrom(from, this, value));
 
     if (0 == donorAmounts[from]) donorCount += 1;
+    if (0 == donorAmounts[from]) allDonors.push(from);
     donations += value;
     donorAmounts[from] += value;
     updateHighestDonors(from);

--- a/contracts/Question.sol
+++ b/contracts/Question.sol
@@ -61,7 +61,7 @@ contract Question {
   function receiveApproval(address from, uint256 value, address _tokenContract, bytes extraData) beforeDeadline {
     require(address(token) == _tokenContract); // necessary?
     require(value > 0);
-    require(token.transferFrom(from, this, value));
+    require(token.transferFrom(from, this, value)); // why is from being used instead of msg.sender?
 
     if (0 == donorAmounts[from]) donorCount += 1;
     if (0 == donorAmounts[from]) allDonors.push(from);

--- a/contracts/Question.sol
+++ b/contracts/Question.sol
@@ -19,6 +19,7 @@ contract Question {
   string public tweetUrl;
   mapping(address => uint) public donorAmounts;
   mapping(address => bool) public donorRevertDonation;
+  address[] = allDonors; // could use an array like this to keep track of all donors instead of just top 5
   HighestDonor[5] public highestDonors;
   uint public donorCount;
   uint256 public donations;
@@ -49,11 +50,16 @@ contract Question {
     donorCount = 1;
     donations = amount;
     donorAmounts[author] = amount;
+    allDonors.push(author);
     highestDonors[0] = HighestDonor({ addr: author, lastDonatedAt: now });
+  }
+  
+  function getDonorAmountByKey (uint key) public constant returns(donation uint) {
+    return donorAmounts[allDonors[key]];
   }
 
   function receiveApproval(address from, uint256 value, address _tokenContract, bytes extraData) beforeDeadline {
-    require(address(token) == _tokenContract);
+    require(address(token) == _tokenContract); // necessary?
     require(value > 0);
     require(token.transferFrom(from, this, value));
 
@@ -63,6 +69,8 @@ contract Question {
     updateHighestDonors(from);
   }
 
+  // expensive computation that could be done on the client side
+  // if date is important maybe this struct should be applied to all donors instead
   function updateHighestDonors(address donor) internal {
     uint amount = donorAmounts[donor];
     if (donorAmounts[highestDonors[4].addr] >= amount) return;
@@ -78,9 +86,9 @@ contract Question {
 
   function answer(string _tweetUrl) beforeDeadline {
     require(msg.sender == backend);
-    tweetUrl = _tweetUrl;
     assert(token.transfer(charityAddress, donations));
-  }
+    tweetUrl = _tweetUrl;
+}
 
   function revertDonation() {
     require(bytes(tweetUrl).length == 0);


### PR DESCRIPTION
i think the top 5 donors is something that would be better performed off the chain.
the loops will be expensive and there's no need for that logic to be in the contract, is there?

the donors could be structs in a mapping of addresses if the time they donated was important. 
this could be managed and queried based on an array of the addresses
check out this [link](https://ethereum.stackexchange.com/questions/13167/are-there-well-solved-and-simple-storage-patterns-for-solidity/13168) for examples of this storage pattern

why is the donation being performed with an explicit from address? this would imply that they are moving the funds on behalf of someone else who has already given them explicit permission with transferFrom() which we make no effort to ensure. much simpler to use transfer and msg.sender, no?